### PR TITLE
Fix/missing rgi results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
    * The plugin will now save the additional fields provided by the newer staramr version in the metadata table.
 * Updated RGI version to `5.1.1`.
 * Updated Shovill to version `1.1.0`.
+* Fixed bug where empty RGI results would lead to metadata not being written (#8)
 
 # 0.1.0
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,12 +6,12 @@
 
 	<groupId>ca.corefacility.bioinformatics.irida</groupId>
 	<artifactId>amr-detection</artifactId>
-	<version>0.3.0-SNAPSHOT</version>
+	<version>0.2.0</version>
 
 	<properties>
 		<plugin.id>amr-detection</plugin.id>
 		<plugin.class>ca.corefacility.bioinformatics.irida.plugin.amrdetection.AMRDetectionPlugin</plugin.class>
-		<plugin.version>0.3.0</plugin.version>
+		<plugin.version>0.2.0</plugin.version>
 		<plugin.provider>Aaron Petkau</plugin.provider>
 		<plugin.dependencies></plugin.dependencies>
 		<plugin.requires.runtime>1.1.0</plugin.requires.runtime>

--- a/src/main/java/ca/corefacility/bioinformatics/irida/plugin/amrdetection/AMRDetectionUpdater.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/plugin/amrdetection/AMRDetectionUpdater.java
@@ -194,24 +194,31 @@ public class AMRDetectionUpdater implements AnalysisSampleUpdater {
 			line = reader.readLine();
 		}
 
-		if (!genotypes.isEmpty()) {
+		String genotypesString = "-";
+		String drugsString = "-";
+
+		if (genotypes.isEmpty()) {
+			logger.info("No genotype results found in rgi output file [" + rgiFilePath + "], for analysis submission " + analysis);
+		} else {
 			Collections.sort(genotypes);
 
-			String genotypesString = joiner.join(genotypes);
+			genotypesString = joiner.join(genotypes);
+		}
 
+		if (drugs.isEmpty()) {
+			logger.info("No drug results found in rgi output file [" + rgiFilePath + "], for analysis submission " + analysis);
+		} else {
 			Set<String> drugsSet = Sets.newTreeSet();
 			drugs.forEach(t -> drugsSet.addAll(Lists.newArrayList(t.split(DRUG_CLASS_SPLIT))));
 
-			String drugsString = joiner.join(drugsSet);
-
-			Map<String, PipelineProvidedMetadataEntry> results = new HashMap<>();
-			results.put(RGI_GENE, new PipelineProvidedMetadataEntry(genotypesString, "text", analysis));
-			results.put(RGI_DRUG_CLASS, new PipelineProvidedMetadataEntry(drugsString, "text", analysis));
-
-			return results;
-		} else {
-			throw new PostProcessingException("No results found in rgi output file [" + rgiFilePath + "]");
+			drugsString = joiner.join(drugsSet);
 		}
+
+		Map<String, PipelineProvidedMetadataEntry> results = new HashMap<>();
+		results.put(RGI_GENE, new PipelineProvidedMetadataEntry(genotypesString, "text", analysis));
+		results.put(RGI_DRUG_CLASS, new PipelineProvidedMetadataEntry(drugsString, "text", analysis));
+
+		return results;
 	}
 
 	/**

--- a/src/main/java/ca/corefacility/bioinformatics/irida/plugin/amrdetection/AMRDetectionUpdater.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/plugin/amrdetection/AMRDetectionUpdater.java
@@ -51,10 +51,13 @@ public class AMRDetectionUpdater implements AnalysisSampleUpdater {
 	private static final String RGI_GENE = "rgi/gene";
 	//
 	// The "Number of Contigs" column is a special case since the name can change
-	// (e.g., the full name is like "Number of Contigs Greater Than Or Equal To 300 bp" where "300 bp" can change).
+	// (e.g., the full name is like "Number of Contigs Greater Than Or Equal To 300
+	// bp" where "300 bp" can change).
 	private static final String STARAMR_RESULTS_CONTIGS_PREFIX = "Number of Contigs Greater Than Or Equal To";
 
-	// Maps IRIDA metadata field name to the column name of the staramr results (e.g., "staramr/quality" => "Quality Module")
+	// Maps IRIDA metadata field name to the column name of the staramr results
+	// (e.g., "staramr/quality" => "Quality Module")
+	//@formatter:off
 	private static final Map<String, String> STARAMR_RESULTS_METADATA_MAP = ImmutableMap.<String, String>builder()
 		.put("staramr/quality"           , "Quality Module")
 		.put("staramr/gene"              , "Genotype")
@@ -67,7 +70,7 @@ public class AMRDetectionUpdater implements AnalysisSampleUpdater {
 		.put("staramr/quality-feedback"  , "Quality Module Feedback")
 		.put("staramr/number-contigs"    , STARAMR_RESULTS_CONTIGS_PREFIX)
 		.build();
-
+	//@formatter:on
 
 	private MetadataTemplateService metadataTemplateService;
 	private SampleService sampleService;
@@ -102,7 +105,7 @@ public class AMRDetectionUpdater implements AnalysisSampleUpdater {
 		final int MIN_TOKENS = 2;
 
 		Map<String, PipelineProvidedMetadataEntry> results = new HashMap<>();
-		Map<String,String> dataMap = new HashMap<>();
+		Map<String, String> dataMap = new HashMap<>();
 
 		@SuppressWarnings("resource")
 		BufferedReader reader = new BufferedReader(new FileReader(staramrFilePath.toFile()));
@@ -117,18 +120,21 @@ public class AMRDetectionUpdater implements AnalysisSampleUpdater {
 
 		List<String> values = new ArrayList<>();
 		if (line == null || line.length() == 0) {
-			logger.info("Got empty results for staramr file [" + staramrFilePath + "] for analysis submission " + analysis);
-		} else { 
+			logger.info(
+					"Got empty results for staramr file [" + staramrFilePath + "] for analysis submission " + analysis);
+		} else {
 			values = SPLITTER.splitToList(line);
-	
+
 			if (columnNames.size() != values.size()) {
-				throw new PostProcessingException("Mismatch in number of column names [" + columnNames.size() + "] and number of files [" + values.size() + "] in staramr results file [" + staramrFilePath + "]");
+				throw new PostProcessingException(
+						"Mismatch in number of column names [" + columnNames.size() + "] and number of files ["
+								+ values.size() + "] in staramr results file [" + staramrFilePath + "]");
 			}
 
 			for (int i = 0; i < columnNames.size(); i++) {
 				String column = columnNames.get(i);
 				String value = values.get(i);
-	
+
 				if (column.startsWith(STARAMR_RESULTS_CONTIGS_PREFIX)) {
 					dataMap.put(STARAMR_RESULTS_CONTIGS_PREFIX, value);
 				} else {
@@ -137,7 +143,7 @@ public class AMRDetectionUpdater implements AnalysisSampleUpdater {
 			}
 		}
 
-		for (String resultsFieldName: STARAMR_RESULTS_METADATA_MAP.keySet()) {
+		for (String resultsFieldName : STARAMR_RESULTS_METADATA_MAP.keySet()) {
 			String staramrColumnName = STARAMR_RESULTS_METADATA_MAP.get(resultsFieldName);
 			String value = dataMap.containsKey(staramrColumnName) ? dataMap.get(staramrColumnName) : "-";
 
@@ -211,7 +217,8 @@ public class AMRDetectionUpdater implements AnalysisSampleUpdater {
 		String drugsString = "-";
 
 		if (genotypes.isEmpty()) {
-			logger.info("No genotype results found in rgi output file [" + rgiFilePath + "], for analysis submission " + analysis);
+			logger.info("No genotype results found in rgi output file [" + rgiFilePath + "], for analysis submission "
+					+ analysis);
 		} else {
 			Collections.sort(genotypes);
 
@@ -219,7 +226,8 @@ public class AMRDetectionUpdater implements AnalysisSampleUpdater {
 		}
 
 		if (drugs.isEmpty()) {
-			logger.info("No drug results found in rgi output file [" + rgiFilePath + "], for analysis submission " + analysis);
+			logger.info("No drug results found in rgi output file [" + rgiFilePath + "], for analysis submission "
+					+ analysis);
 		} else {
 			Set<String> drugsSet = Sets.newTreeSet();
 			drugs.forEach(t -> drugsSet.addAll(Lists.newArrayList(t.split(DRUG_CLASS_SPLIT))));


### PR DESCRIPTION
This refactors some of the code used to parse the results and write to our metadata tables. A few things it fixes:

# Changes

1. It fixes this issue https://github.com/phac-nml/irida-plugin-amr-detection/issues/8 which was causing an error when writing metadata if the RGI results were empty. My fix changes the code so that if any fields are missing in either RGI or staramr then the character `-` will be written to the that particular field in the table (instead of throwing an Exception and causing the entire metadata write to fail).
2. This changes parsing of the results files (e.g., `staramr-summary.tsv`) to not rely on the column number but instead to use the column name (e.g., it won't rely on the GENOTYPE information being in column `2`, but instead rely on the column name `Genotype`). This is because, depending on the parameters you set in the tool, some columns for staramr can be added or removed from the final results file.

# Testing

To test you will have to first install IRIDA `21.01` to a local maven repository with the command (run from the IRIDA directory):

```bash
mvn clean install -DskipTests
```

Then you can compile this code into a package and copy to the `/etc/irida/plugins` directory:

```bash
mvn clean package
cp target/amr-detection-0.2.0.jar /etc/irida/plugins
```

Now, to test out you will need to start up Galaxy and install the appropriate tools:

```bash
docker run -d -p 3000:80 -v /path/to/irida/data:/path/to/irida/data phacnml/galaxy-irida-20.05
```

Now, you will have to login to the Galaxy instance (username: `admin@galaxy.org`, password: `password`) and go to **Admin > Install and Uninstall** and install the appropriate versions of tools:

* staramr version `0.7.2+galaxy0`
* RGI version `5.1.1`

Now, you can start up IRIDA and test out. So to test out point (1) (the bug) you can use the below files which will have a results for staramr but not for RGI.

* [missing_RGI_R1.fastq.gz](https://github.com/phac-nml/irida-plugin-amr-detection/files/6161426/missing_RGI_R1.fastq.gz)
* [missing_RGI_R2.fastq.gz](https://github.com/phac-nml/irida-plugin-amr-detection/files/6161428/missing_RGI_R2.fastq.gz)
