### PR TITLE
Set RGI database to 'amr_detection'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target
 /.project
 /.classpath
 /.settings
+/irida

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.1
+
+* Set RGI database to 'amr_detection'. A database with this name must be preloaded using the RGI data manager tool.
+
 # 0.2.0
 
 * Updated writing of metadata to be compatible with IRIDA `21.01` update.

--- a/pom.xml
+++ b/pom.xml
@@ -6,12 +6,12 @@
 
 	<groupId>ca.corefacility.bioinformatics.irida</groupId>
 	<artifactId>amr-detection</artifactId>
-	<version>0.3.0-SNAPSHOT</version>
+	<version>0.2.1</version>
 
 	<properties>
 		<plugin.id>amr-detection</plugin.id>
 		<plugin.class>ca.corefacility.bioinformatics.irida.plugin.amrdetection.AMRDetectionPlugin</plugin.class>
-		<plugin.version>0.2.0</plugin.version>
+		<plugin.version>0.2.1</plugin.version>
 		<plugin.provider>Aaron Petkau</plugin.provider>
 		<plugin.dependencies></plugin.dependencies>
 		<plugin.requires.runtime>1.1.0</plugin.requires.runtime>
@@ -21,7 +21,7 @@
 		<java.version>11</java.version>
 		<maven.compiler.release>11</maven.compiler.release>
 		
-		<irida.version.compiletime>21.01</irida.version.compiletime>
+		<irida.version.compiletime>21.05.3</irida.version.compiletime>
 
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>ca.corefacility.bioinformatics.irida</groupId>
 	<artifactId>amr-detection</artifactId>
-	<version>0.2.0</version>
+	<version>0.3.0-SNAPSHOT</version>
 
 	<properties>
 		<plugin.id>amr-detection</plugin.id>

--- a/src/main/java/ca/corefacility/bioinformatics/irida/plugin/amrdetection/AMRDetectionPlugin.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/plugin/amrdetection/AMRDetectionPlugin.java
@@ -50,7 +50,7 @@ public class AMRDetectionPlugin extends Plugin {
 
 		@Override
 		public UUID getDefaultWorkflowUUID() {
-			return UUID.fromString("338c48c9-7a4b-43f3-8ef9-cb217509cf53");
+			return UUID.fromString("17fcb9f1-9501-4530-b45b-6d0673a368d1");
 		}
 
 		@Override

--- a/src/main/resources/workflows/0.2.1/irida_workflow.xml
+++ b/src/main/resources/workflows/0.2.1/irida_workflow.xml
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iridaWorkflow>
+  <id>17fcb9f1-9501-4530-b45b-6d0673a368d1</id>
+  <name>amr-detection</name>
+  <version>0.2.1</version>
+  <analysisType>AMR_DETECTION</analysisType>
+  <inputs>
+    <sequenceReadsPaired>sequence_reads_paired</sequenceReadsPaired>
+    <requiresSingleSample>true</requiresSingleSample>
+  </inputs>
+  <parameters>
+    <parameter name="shovill-1-adv.nocorr" defaultValue="false">
+      <toolParameter toolId="toolshed.g2.bx.psu.edu/repos/iuc/shovill/shovill/1.1.0+galaxy0" parameterName="adv.nocorr"/>
+    </parameter>
+    <parameter name="shovill-1-adv.mincov" defaultValue="1">
+      <toolParameter toolId="toolshed.g2.bx.psu.edu/repos/iuc/shovill/shovill/1.1.0+galaxy0" parameterName="adv.mincov"/>
+    </parameter>
+    <parameter name="shovill-1-trim" defaultValue="false">
+      <toolParameter toolId="toolshed.g2.bx.psu.edu/repos/iuc/shovill/shovill/1.1.0+galaxy0" parameterName="trim"/>
+    </parameter>
+    <parameter name="shovill-1-adv.namefmt" defaultValue="contig%05d">
+      <toolParameter toolId="toolshed.g2.bx.psu.edu/repos/iuc/shovill/shovill/1.1.0+galaxy0" parameterName="adv.namefmt"/>
+    </parameter>
+    <parameter name="shovill-1-adv.depth" defaultValue="100">
+      <toolParameter toolId="toolshed.g2.bx.psu.edu/repos/iuc/shovill/shovill/1.1.0+galaxy0" parameterName="adv.depth"/>
+    </parameter>
+    <parameter name="shovill-1-adv.gsize" defaultValue="">
+      <toolParameter toolId="toolshed.g2.bx.psu.edu/repos/iuc/shovill/shovill/1.1.0+galaxy0" parameterName="adv.gsize"/>
+    </parameter>
+    <parameter name="shovill-1-adv.kmers" defaultValue="">
+      <toolParameter toolId="toolshed.g2.bx.psu.edu/repos/iuc/shovill/shovill/1.1.0+galaxy0" parameterName="adv.kmers"/>
+    </parameter>
+    <parameter name="shovill-1-adv.opts" defaultValue="">
+      <toolParameter toolId="toolshed.g2.bx.psu.edu/repos/iuc/shovill/shovill/1.1.0+galaxy0" parameterName="adv.opts"/>
+    </parameter>
+    <parameter name="shovill-1-adv.minlen" defaultValue="1">
+      <toolParameter toolId="toolshed.g2.bx.psu.edu/repos/iuc/shovill/shovill/1.1.0+galaxy0" parameterName="adv.minlen"/>
+    </parameter>
+    <parameter name="shovill-1-assembler" defaultValue="spades">
+      <toolParameter toolId="toolshed.g2.bx.psu.edu/repos/iuc/shovill/shovill/1.1.0+galaxy0" parameterName="assembler"/>
+    </parameter>
+    <parameter name="staramr-2-use_pointfinder" defaultValue="disabled">
+      <toolParameter toolId="toolshed.g2.bx.psu.edu/repos/nml/staramr/staramr_search/0.7.2+galaxy0" parameterName="use_pointfinder"/>
+    </parameter>
+    <parameter name="staramr-2-advanced.plength_plasmidfinder" defaultValue="60.0">
+      <toolParameter toolId="toolshed.g2.bx.psu.edu/repos/nml/staramr/staramr_search/0.7.2+galaxy0" parameterName="advanced.plength_plasmidfinder"/>
+    </parameter>
+    <parameter name="staramr-2-advanced.exclude_negatives" defaultValue="false">
+      <toolParameter toolId="toolshed.g2.bx.psu.edu/repos/nml/staramr/staramr_search/0.7.2+galaxy0" parameterName="advanced.exclude_negatives"/>
+    </parameter>
+    <parameter name="staramr-2-advanced.plength_resfinder" defaultValue="60.0">
+      <toolParameter toolId="toolshed.g2.bx.psu.edu/repos/nml/staramr/staramr_search/0.7.2+galaxy0" parameterName="advanced.plength_resfinder"/>
+    </parameter>
+    <parameter name="staramr-2-advanced.genome_size_lower_bound" defaultValue="4000000">
+      <toolParameter toolId="toolshed.g2.bx.psu.edu/repos/nml/staramr/staramr_search/0.7.2+galaxy0" parameterName="advanced.genome_size_lower_bound"/>
+    </parameter>
+    <parameter name="staramr-2-advanced.mlst_scheme" defaultValue="auto">
+      <toolParameter toolId="toolshed.g2.bx.psu.edu/repos/nml/staramr/staramr_search/0.7.2+galaxy0" parameterName="advanced.mlst_scheme"/>
+    </parameter>
+    <parameter name="staramr-2-advanced.exclude_genes.exclude_genes_condition" defaultValue="default">
+      <toolParameter toolId="toolshed.g2.bx.psu.edu/repos/nml/staramr/staramr_search/0.7.2+galaxy0" parameterName="advanced.exclude_genes.exclude_genes_condition"/>
+    </parameter>
+    <parameter name="staramr-2-advanced.plength_pointfinder" defaultValue="95.0">
+      <toolParameter toolId="toolshed.g2.bx.psu.edu/repos/nml/staramr/staramr_search/0.7.2+galaxy0" parameterName="advanced.plength_pointfinder"/>
+    </parameter>
+    <parameter name="staramr-2-advanced.minimum_contig_length" defaultValue="300">
+      <toolParameter toolId="toolshed.g2.bx.psu.edu/repos/nml/staramr/staramr_search/0.7.2+galaxy0" parameterName="advanced.minimum_contig_length"/>
+    </parameter>
+    <parameter name="staramr-2-advanced.minimum_N50_value" defaultValue="10000">
+      <toolParameter toolId="toolshed.g2.bx.psu.edu/repos/nml/staramr/staramr_search/0.7.2+galaxy0" parameterName="advanced.minimum_N50_value"/>
+    </parameter>
+    <parameter name="staramr-2-advanced.genome_size_upper_bound" defaultValue="6000000">
+      <toolParameter toolId="toolshed.g2.bx.psu.edu/repos/nml/staramr/staramr_search/0.7.2+galaxy0" parameterName="advanced.genome_size_upper_bound"/>
+    </parameter>
+    <parameter name="staramr-2-advanced.exclude_resistance_phenotypes" defaultValue="false">
+      <toolParameter toolId="toolshed.g2.bx.psu.edu/repos/nml/staramr/staramr_search/0.7.2+galaxy0" parameterName="advanced.exclude_resistance_phenotypes"/>
+    </parameter>
+    <parameter name="staramr-2-advanced.plasmidfinder_type" defaultValue="include_all">
+      <toolParameter toolId="toolshed.g2.bx.psu.edu/repos/nml/staramr/staramr_search/0.7.2+galaxy0" parameterName="advanced.plasmidfinder_type"/>
+    </parameter>
+    <parameter name="staramr-2-advanced.report_all_blast" defaultValue="false">
+      <toolParameter toolId="toolshed.g2.bx.psu.edu/repos/nml/staramr/staramr_search/0.7.2+galaxy0" parameterName="advanced.report_all_blast"/>
+    </parameter>
+    <parameter name="staramr-2-advanced.unacceptable_number_contigs" defaultValue="1000">
+      <toolParameter toolId="toolshed.g2.bx.psu.edu/repos/nml/staramr/staramr_search/0.7.2+galaxy0" parameterName="advanced.unacceptable_number_contigs"/>
+    </parameter>
+    <parameter name="staramr-2-advanced.pid_threshold" defaultValue="98.0">
+      <toolParameter toolId="toolshed.g2.bx.psu.edu/repos/nml/staramr/staramr_search/0.7.2+galaxy0" parameterName="advanced.pid_threshold"/>
+    </parameter>
+    <parameter name="rgi-3-low_quality" defaultValue="false">
+      <toolParameter toolId="toolshed.g2.bx.psu.edu/repos/card/rgi/rgi/5.1.1" parameterName="low_quality"/>
+    </parameter>
+    <parameter name="rgi-3-alignment_tool" defaultValue="diamond">
+      <toolParameter toolId="toolshed.g2.bx.psu.edu/repos/card/rgi/rgi/5.1.1" parameterName="alignment_tool"/>
+    </parameter>
+    <parameter name="rgi-3-data" defaultValue="NA">
+      <toolParameter toolId="toolshed.g2.bx.psu.edu/repos/card/rgi/rgi/5.1.1" parameterName="data"/>
+    </parameter>
+    <parameter name="rgi-3-include_loose" defaultValue="false">
+      <toolParameter toolId="toolshed.g2.bx.psu.edu/repos/card/rgi/rgi/5.1.1" parameterName="include_loose"/>
+    </parameter>
+  </parameters>
+  <outputs>
+    <output name="staramr-summary.tsv" fileName="staramr-summary.tsv"/>
+    <output name="staramr-detailed-summary.tsv" fileName="staramr-detailed-summary.tsv"/>
+    <output name="rgi-summary.tsv" fileName="rgi-summary.tsv"/>
+    <output name="staramr-resfinder.tsv" fileName="staramr-resfinder.tsv"/>
+    <output name="staramr-plasmidfinder.tsv" fileName="staramr-plasmidfinder.tsv"/>
+    <output name="staramr-mlst.tsv" fileName="staramr-mlst.tsv"/>
+    <output name="staramr-excel.xlsx" fileName="staramr-excel.xlsx"/>
+    <output name="staramr-settings.txt" fileName="staramr-settings.txt"/>
+    <output name="shovill-contigs.fasta" fileName="shovill-contigs.fasta"/>
+    <output name="shovill-contigs.gfa" fileName="shovill-contigs.gfa"/>
+    <output name="rgi-report.json" fileName="rgi-report.json"/>
+    <output name="shovill-std.log" fileName="shovill-std.log"/>
+  </outputs>
+  <toolRepositories>
+    <repository>
+      <name>shovill</name>
+      <owner>iuc</owner>
+      <url>https://toolshed.g2.bx.psu.edu</url>
+      <revision>83ead2be47b2</revision>
+    </repository>
+    <repository>
+      <name>rgi</name>
+      <owner>card</owner>
+      <url>https://toolshed.g2.bx.psu.edu</url>
+      <revision>bfbfc24c5af2</revision>
+    </repository>
+    <repository>
+      <name>staramr</name>
+      <owner>nml</owner>
+      <url>https://toolshed.g2.bx.psu.edu</url>
+      <revision>4b9a8031ab74</revision>
+    </repository>
+  </toolRepositories>
+</iridaWorkflow>

--- a/src/main/resources/workflows/0.2.1/irida_workflow.xml
+++ b/src/main/resources/workflows/0.2.1/irida_workflow.xml
@@ -99,6 +99,12 @@
     <parameter name="rgi-3-include_loose" defaultValue="false">
       <toolParameter toolId="toolshed.g2.bx.psu.edu/repos/card/rgi/rgi/5.1.1" parameterName="include_loose"/>
     </parameter>
+    <parameter name="rgi_database" required="true">
+      <dynamicSource>
+        <galaxyToolDataTable name="rgi_databases" displayColumn="name" parameterColumn="value" />
+      </dynamicSource>
+      <toolParameter toolId="toolshed.g2.bx.psu.edu/repos/card/rgi/rgi/5.1.1" parameterName="rgi_db_local" />
+    </parameter>
   </parameters>
   <outputs>
     <output name="staramr-summary.tsv" fileName="staramr-summary.tsv"/>

--- a/src/main/resources/workflows/0.2.1/irida_workflow_structure.ga
+++ b/src/main/resources/workflows/0.2.1/irida_workflow_structure.ga
@@ -1,0 +1,357 @@
+{
+    "a_galaxy_workflow": "true",
+    "annotation": "",
+    "format-version": "0.1",
+    "name": "AMR Detection (0.2.1)",
+    "steps": {
+        "0": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 0,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "sequence_reads_paired"
+                }
+            ],
+            "label": "sequence_reads_paired",
+            "name": "Input dataset collection",
+            "outputs": [],
+            "position": {
+                "left": 200,
+                "top": 200
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false, \"collection_type\": \"list:paired\"}",
+            "tool_version": null,
+            "type": "data_collection_input",
+            "uuid": "f39af4f6-29a6-4358-84b4-3319899cbb12",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "7bca5aab-40da-470f-95d9-033741a45aa3"
+                }
+            ]
+        },
+        "1": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/shovill/shovill/1.1.0+galaxy0",
+            "errors": null,
+            "id": 1,
+            "input_connections": {
+                "library|input1": {
+                    "id": 0,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Shovill",
+            "outputs": [
+                {
+                    "name": "shovill_std_log",
+                    "type": "txt"
+                },
+                {
+                    "name": "contigs",
+                    "type": "fasta"
+                },
+                {
+                    "name": "contigs_graph",
+                    "type": "txt"
+                }
+            ],
+            "position": {
+                "left": 486,
+                "top": 200
+            },
+            "post_job_actions": {
+                "RenameDatasetActioncontigs": {
+                    "action_arguments": {
+                        "newname": "shovill-contigs.fasta"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "contigs"
+                },
+                "RenameDatasetActioncontigs_graph": {
+                    "action_arguments": {
+                        "newname": "shovill-contigs.gfa"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "contigs_graph"
+                },
+                "RenameDatasetActionshovill_std_log": {
+                    "action_arguments": {
+                        "newname": "shovill-std.log"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "shovill_std_log"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/shovill/shovill/1.1.0+galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "83ead2be47b2",
+                "name": "shovill",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"adv\": {\"namefmt\": \"contig%05d\", \"depth\": \"100\", \"gsize\": \"\", \"kmers\": \"\", \"opts\": \"\", \"nocorr\": \"false\", \"minlen\": \"300\", \"mincov\": \"1\"}, \"assembler\": \"spades\", \"library\": {\"lib_type\": \"collection\", \"__current_case__\": 1, \"input1\": {\"__class__\": \"ConnectedValue\"}}, \"log\": \"true\", \"trim\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.1.0+galaxy0",
+            "type": "tool",
+            "uuid": "a1207389-35e5-42da-9012-20b099205871",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "contigs",
+                    "uuid": "276cd805-a60b-4075-9176-330801cda242"
+                },
+                {
+                    "label": null,
+                    "output_name": "shovill_std_log",
+                    "uuid": "b71fabd9-e639-41ea-8d8d-7ef105854fa6"
+                },
+                {
+                    "label": null,
+                    "output_name": "contigs_graph",
+                    "uuid": "6986c11d-5876-43eb-889c-aa1153dfaec4"
+                }
+            ]
+        },
+        "2": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/nml/staramr/staramr_search/0.7.2+galaxy0",
+            "errors": null,
+            "id": 2,
+            "input_connections": {
+                "genomes": {
+                    "id": 1,
+                    "output_name": "contigs"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool staramr",
+                    "name": "genomes"
+                }
+            ],
+            "label": null,
+            "name": "staramr",
+            "outputs": [
+                {
+                    "name": "blast_hits",
+                    "type": "input"
+                },
+                {
+                    "name": "mlst",
+                    "type": "tabular"
+                },
+                {
+                    "name": "summary",
+                    "type": "tabular"
+                },
+                {
+                    "name": "detailed_summary",
+                    "type": "tabular"
+                },
+                {
+                    "name": "resfinder",
+                    "type": "tabular"
+                },
+                {
+                    "name": "plasmidfinder",
+                    "type": "tabular"
+                },
+                {
+                    "name": "settings",
+                    "type": "txt"
+                },
+                {
+                    "name": "excel",
+                    "type": "xlsx"
+                }
+            ],
+            "position": {
+                "left": 772,
+                "top": 200
+            },
+            "post_job_actions": {
+                "HideDatasetActionblast_hits": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "blast_hits"
+                },
+                "RenameDatasetActiondetailed_summary": {
+                    "action_arguments": {
+                        "newname": "staramr-detailed-summary.tsv"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "detailed_summary"
+                },
+                "RenameDatasetActionexcel": {
+                    "action_arguments": {
+                        "newname": "staramr-excel.xlsx"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "excel"
+                },
+                "RenameDatasetActionmlst": {
+                    "action_arguments": {
+                        "newname": "staramr-mlst.tsv"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "mlst"
+                },
+                "RenameDatasetActionplasmidfinder": {
+                    "action_arguments": {
+                        "newname": "staramr-plasmidfinder.tsv"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "plasmidfinder"
+                },
+                "RenameDatasetActionresfinder": {
+                    "action_arguments": {
+                        "newname": "staramr-resfinder.tsv"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "resfinder"
+                },
+                "RenameDatasetActionsettings": {
+                    "action_arguments": {
+                        "newname": "staramr-settings.txt"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "settings"
+                },
+                "RenameDatasetActionsummary": {
+                    "action_arguments": {
+                        "newname": "staramr-summary.tsv"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "summary"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/nml/staramr/staramr_search/0.7.2+galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "4b9a8031ab74",
+                "name": "staramr",
+                "owner": "nml",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"advanced\": {\"pid_threshold\": \"98.0\", \"plength_resfinder\": \"60.0\", \"plength_pointfinder\": \"95.0\", \"plength_plasmidfinder\": \"60.0\", \"genome_size_lower_bound\": \"4000000\", \"genome_size_upper_bound\": \"6000000\", \"minimum_N50_value\": \"10000\", \"minimum_contig_length\": \"300\", \"unacceptable_number_contigs\": \"1000\", \"report_all_blast\": \"false\", \"exclude_negatives\": \"false\", \"exclude_resistance_phenotypes\": \"false\", \"mlst_scheme\": \"auto\", \"exclude_genes\": {\"exclude_genes_condition\": \"default\", \"__current_case__\": 0}, \"plasmidfinder_type\": \"include_all\"}, \"genomes\": {\"__class__\": \"RuntimeValue\"}, \"use_pointfinder\": \"disabled\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.7.2+galaxy0",
+            "type": "tool",
+            "uuid": "e61df3a1-dd74-408a-9c03-fbb690bd2db5",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "excel",
+                    "uuid": "b33dc062-c189-4405-9b19-b68cb7692152"
+                },
+                {
+                    "label": null,
+                    "output_name": "detailed_summary",
+                    "uuid": "b0f9fe88-e402-4a2d-a83f-90b31283bb6f"
+                },
+                {
+                    "label": null,
+                    "output_name": "settings",
+                    "uuid": "95f87b65-aa08-4a52-b075-66f1665bbb21"
+                },
+                {
+                    "label": null,
+                    "output_name": "summary",
+                    "uuid": "bba0dfb4-e67f-4bbe-939a-47eedcd0102b"
+                },
+                {
+                    "label": null,
+                    "output_name": "resfinder",
+                    "uuid": "102e88ce-0030-453d-8ca6-77960e1302c7"
+                },
+                {
+                    "label": null,
+                    "output_name": "plasmidfinder",
+                    "uuid": "46a1a881-b180-4b85-823d-6d0a3af0830d"
+                },
+                {
+                    "label": null,
+                    "output_name": "mlst",
+                    "uuid": "b105e443-b599-4dfa-a3bc-d09af53d486f"
+                }
+            ]
+        },
+        "3": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/card/rgi/rgi/5.1.1",
+            "errors": null,
+            "id": 3,
+            "input_connections": {
+                "input_sequence": {
+                    "id": 1,
+                    "output_name": "contigs"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Resistance Gene Identifier (RGI)",
+            "outputs": [
+                {
+                    "name": "report",
+                    "type": "json"
+                },
+                {
+                    "name": "summary",
+                    "type": "tabular"
+                }
+            ],
+            "position": {
+                "left": 772,
+                "top": 799
+            },
+            "post_job_actions": {
+                "RenameDatasetActionreport": {
+                    "action_arguments": {
+                        "newname": "rgi-report.json"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "report"
+                },
+                "RenameDatasetActionsummary": {
+                    "action_arguments": {
+                        "newname": "rgi-summary.tsv"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "summary"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/card/rgi/rgi/5.1.1",
+            "tool_shed_repository": {
+                "changeset_revision": "bfbfc24c5af2",
+                "name": "rgi",
+                "owner": "card",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"alignment_tool\": \"diamond\", \"data\": \"NA\", \"db_opts\": {\"db_opts_selector\": \"local\", \"__current_case__\": 1, \"rgi_db_local\": \"amr_detection\", \"rgi_db_hist\": \"\"}, \"include_loose\": \"false\", \"input_sequence\": {\"__class__\": \"RuntimeValue\"}, \"input_type\": \"contig\", \"low_quality\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "5.1.1",
+            "type": "tool",
+            "uuid": "e54fe3ce-89a9-4c00-8e17-2ac46fedd11c",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "summary",
+                    "uuid": "0d9dd88b-40b9-48c6-b2eb-49433a293766"
+                },
+                {
+                    "label": null,
+                    "output_name": "report",
+                    "uuid": "d4542103-0200-4979-b220-097d0d5391a4"
+                }
+            ]
+        }
+    },
+    "tags": [],
+    "uuid": "28d4b084-eb95-49ae-ac1f-268a4311368c",
+    "version": 1
+}

--- a/src/main/resources/workflows/0.2.1/messages_en.properties
+++ b/src/main/resources/workflows/0.2.1/messages_en.properties
@@ -1,0 +1,44 @@
+#Pipeline Info Properties
+#Thu Jan 07 13:09:25 CST 2021
+pipeline.parameters.modal-title.amr-detection=AMR Detection Pipeline Parameters
+workflow.AMR_DETECTION.description=A pipeline to search microbial genomes for antimicrobial resistance genes (AMR). Uses the tools RGI and StarAMR.
+workflow.label.share-analysis-samples.AMR_DETECTION=Save AMR detection results to Project Line List Metadata
+workflow.AMR_DETECTION.title=AMR Detection Pipeline
+pipeline.title.amr-detection=Pipelines - AMR Detection
+pipeline.h1.amr-detection=AMR Detection Pipeline
+#Tool Parameters - Tool: shovill - Workflow Step #: 1
+#Thu Jan 07 13:09:25 CST 2021
+pipeline.parameters.amr-detection.shovill-1-adv.minlen=Minimum contig length
+pipeline.parameters.amr-detection.shovill-1-adv.gsize=Estimated genome size
+pipeline.parameters.amr-detection.shovill-1-adv.kmers=List of kmer sizes to use
+pipeline.parameters.amr-detection.shovill-1-adv.opts=Extra SPAdes options
+pipeline.parameters.amr-detection.shovill-1-adv.mincov=Minimum contig coverage
+pipeline.parameters.amr-detection.shovill-1-adv.nocorr=Disable post-assembly correction {true, false}
+pipeline.parameters.amr-detection.shovill-1-adv.namefmt=Contig name format
+pipeline.parameters.amr-detection.shovill-1-assembler=Assembler to use {Spades, skesa, megahit, velvet}
+pipeline.parameters.amr-detection.shovill-1-trim=Trim reads {true, false}
+pipeline.parameters.amr-detection.shovill-1-adv.depth=Depth
+#Tool Parameters - Tool: staramr - Workflow Step #: 2
+#Thu Jan 07 13:09:25 CST 2021
+pipeline.parameters.amr-detection.staramr-2-use_pointfinder=Scan for point mutations using the selected PointFinder database {disabled, salmonella, campylobacter}
+pipeline.parameters.amr-detection.staramr-2-advanced.plength_pointfinder=Percent length overlap of BLAST hit for PointFinder database
+pipeline.parameters.amr-detection.staramr-2-advanced.exclude_negatives=Exclude negative (non-resistant) results {true, false}
+pipeline.parameters.amr-detection.staramr-2-advanced.report_all_blast=Report all BLAST results {true, false}
+pipeline.parameters.amr-detection.staramr-2-advanced.genome_size_upper_bound=The upper bound for our genome size for the quality metrics
+pipeline.parameters.amr-detection.staramr-2-advanced.plasmidfinder_type=Specify PlasmidFinder Database type {include_all, gram_positive, enterobacteriaceae}
+pipeline.parameters.amr-detection.staramr-2-advanced.exclude_genes.exclude_genes_condition=Exclude certain AMR genes from the results {default, none}
+pipeline.parameters.amr-detection.staramr-2-advanced.mlst_scheme=MLST Scheme {auto, or see list from staramr Galaxy tool}
+pipeline.parameters.amr-detection.staramr-2-advanced.plength_plasmidfinder=Percent length overlap of BLAST hit for PlasmidFinder database
+pipeline.parameters.amr-detection.staramr-2-advanced.minimum_contig_length=The minimum contig length for the quality metrics
+pipeline.parameters.amr-detection.staramr-2-advanced.plength_resfinder=Percent length overlap of BLAST hit for ResFinder database
+pipeline.parameters.amr-detection.staramr-2-advanced.pid_threshold=Percent identity threshold for BLAST
+pipeline.parameters.amr-detection.staramr-2-advanced.minimum_N50_value=The minimum N50 value for the quality metrics
+pipeline.parameters.amr-detection.staramr-2-advanced.unacceptable_number_contigs=The number of contigs, under the minimum contig length which is unacceptable for the quality metrics
+pipeline.parameters.amr-detection.staramr-2-advanced.exclude_resistance_phenotypes=Exclude resistance phenotypes {true, false}
+pipeline.parameters.amr-detection.staramr-2-advanced.genome_size_lower_bound=The lower bound for our genome size for the quality metrics
+#Tool Parameters - Tool: rgi - Workflow Step #: 3
+#Thu Jan 07 13:09:25 CST 2021
+pipeline.parameters.amr-detection.rgi-3-low_quality=Include low quality results {true, false}
+pipeline.parameters.amr-detection.rgi-3-include_loose=Include loose hits {true, false}
+pipeline.parameters.amr-detection.rgi-3-alignment_tool=Alignment tool to use {blast, diamond}
+pipeline.parameters.amr-detection.rgi-3-data=Type of data {wgs, plasmid, chromosome, NA}.


### PR DESCRIPTION
A database with this name must be preloaded using the RGI data manager tool.

Resolves: #15 
[amr-detection-0.2.1.jar.gz](https://github.com/phac-nml/irida-plugin-amr-detection/files/6946486/amr-detection-0.2.1.jar.gz)



